### PR TITLE
fix patients_summary に 小計0 のデータができないように応急処置した

### DIFF
--- a/build_json.py
+++ b/build_json.py
@@ -38,12 +38,13 @@ for i in range(days_num):
 
 patients_summary_list = []
 
+# 小計0のデータは作成されないよう応急処置
 for date in datelist:
-    patients_summary_dic.setdefault(date.strftime('%Y-%m-%d'), 0)
-    patients_summary_list.append({
-        "日付": date.strftime('%Y-%m-%d'),
-        "小計": patients_summary_dic[date.strftime('%Y-%m-%d')]
-    })
+    if date.strftime('%Y-%m-%d') in patients_summary_dic:
+        patients_summary_list.append({
+            "日付": date.strftime('%Y-%m-%d'),
+            "小計": patients_summary_dic[date.strftime('%Y-%m-%d')]
+        })
 
 main_summary_dic = {}
 


### PR DESCRIPTION
https://github.com/code4nagoya/covid19-aichi-tools/issues/19

とりあえず patients_summary の日毎の集計で件数:0の項目が作成されないようにしました。

https://github.com/code4nagoya/covid19-aichi-tools/issues/19#issuecomment-613202959 の通り、根本解決にはなっていませんが、まだ発表されていない直近日が 0件 となる問題を回避できます。