### PR TITLE
初回の GitHub Actions 起動時刻を AM10時 に変更

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name : generate data.json other files
 on : 
   push :
   schedule :
-    - cron : '0 0,4,9 * * *' #UTC
-#    - cron : '0 9,13,18 * * *' JST
+    - cron : '0 1,4,9 * * *' #UTC
+#    - cron : '0 10,13,18 * * *' JST
 
 jobs:
   build:


### PR DESCRIPTION
愛知県のデータ更新が AM9:00 過ぎに行われ、メンバによる転記が程なくして行われることが多いので、初回の起動時間を少し遅らせた方がよいということになりました。