### PR TITLE
愛知県サイトのリンクタイトル変更に追従

### DIFF
--- a/scrape_patients.py
+++ b/scrape_patients.py
@@ -51,7 +51,7 @@ def findpath(url):
     for aa in soup.find_all("a"):
         link = aa.get("href")
         name = aa.get_text()
-        if "県内発生事例一覧" in name:
+        if "愛知県内発生事例" in name:
             table_link = link
             if "Excelファイル" in name:
                 ext = "xlsx"


### PR DESCRIPTION
6/28 以降、愛知県サイトの変更で data.json が 0kb になっていたことの対応。