### PR TITLE
GitHub Actions で scrape_inspections.py を復活

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name : generate data.json other files
 on : 
   push :
+    branches:
+      - master
   schedule :
     - cron : '0 1,4,9 * * *' #UTC
 #    - cron : '0 10,13,18 * * *' JST

--- a/README.md
+++ b/README.md
@@ -160,3 +160,21 @@ $ docker build . -t covid19-aichi-tools
 $ docker run --rm -v /covid19/data:./data covid19-aichi-tools
 $ ls -lh data/
 ```
+
+## Docker環境について(docker-compose 版)
+
+[docker-compose](http://docs.docker.jp/compose/install.html) がインストールされていれば、以下のコマンドで実行できます。
+スクリプトを変更しながら Docker 上での動作を確認したいときに便利です。
+
+```
+$ docker-compose run --rm covid19-aichi-tool
+```
+
+``/data`` に結果が出力されます。
+
+### Docker Image の削除
+
+毎回行う必要はありません。しばらく開発から離れる場合や容量不足の時に実行してください。
+
+1. ``docker image`` で Docker Image して "covid19-aichi-tools" の名前が付いているものを見つける
+2. ``docker rmi image名`` で削除

--- a/build_json.py
+++ b/build_json.py
@@ -66,7 +66,7 @@ with open('data/inspections_summary.csv', 'r', encoding="utf-8") as csvfile:
     for row in reader:
         inspections_summary_list.append({
             "日付": datetime.strptime(row['検査日'], '%Y/%m/%d').strftime('%Y-%m-%d'),
-            "小計": int(row['検査件数（件）']),
+            "小計": int(row['陽性者数（人）']),
             "合算": row['合算']
         })
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.1'
+services:
+  covid19-aichi-tool:
+    build: ./
+    container_name: covid19-aichi-tool
+    restart: always
+    volumes:
+      - ./data:/covid19/data
+      - ./:/covid19
+    working_dir: "/covid19"

--- a/docker_exec.sh
+++ b/docker_exec.sh
@@ -7,12 +7,10 @@ wget "https://docs.google.com/spreadsheets/d/1-w8rowCmCG7lmuo5c0jQ0Dh2Frl4hOmpVr
 
 
 # 愛知県HPから感染者一覧を取得してスクレイピング
-python3 /covid19/scrape_patients.py #PDF版
-# python3 /covid19/scrape_patients_excel.py # EXCEL版
+python3 /covid19/scrape_patients.py
 
 # 愛知県HPから新型コロナウイルス遺伝子検査件数を取得してスクレイピング
-# python3 /covid19/scrape_inspections.py
-wget "https://raw.githubusercontent.com/code4nagoya/covid19/development/data/inspections_summary.csv" -O /covid19/data/inspections_summary.csv
+python3 /covid19/scrape_inspections.py
 
 python3 /covid19/build_json.py `date -d "1 day ago" +'%Y-%m-%d'` > /covid19/data/data.json
 


### PR DESCRIPTION
see https://github.com/code4nagoya/covid19-aichi-tools/issues/50

## おまけ

- docker-compose.yml を追加、ローカルで実行しやすくなりました
- GitHub Actions の起動トリガーを master ブランチのみにしました