### PR TITLE
月合算行（２月～６月）を対象から除外

### DIFF
--- a/scrape_inspections.py
+++ b/scrape_inspections.py
@@ -19,6 +19,9 @@ def convert_table(url):
     # 集計行削除
     df.drop(df.tail(1).index,inplace=True)
     
+    # 月別行を削除（応急処置）
+    df.drop([0, 1, 2, 3, 4],inplace=True)
+    
     # 属性調整
     df["備考"] = df["検査日"]
     df["合算"] = df["備考"].apply(is_total)


### PR DESCRIPTION
愛知県サイトの 「3．愛知県内の検査件数」 https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html が、月別に合算され、データ抽出プログラムが対応できおらずエラーとなるので、応急処置として、月別に合算された行（２月～６月）をスキップするようにした。

![image](https://user-images.githubusercontent.com/401369/89705910-15145100-d99c-11ea-8522-ded34f6e1dd2.png)
