### PR TITLE
愛知県HPで感染者一覧PDFが公開されなくなったのでGoogleスプレッドシートを復活

### DIFF
--- a/docker_exec.sh
+++ b/docker_exec.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# wget "https://docs.google.com/spreadsheets/d/12qStuXjsI8GE8qI1mLPLV--6TQcxAMPDu3-k9RCHN1k/export?format=csv&gid=0" -O /covid19/data/patients.csv
+wget "https://docs.google.com/spreadsheets/d/12qStuXjsI8GE8qI1mLPLV--6TQcxAMPDu3-k9RCHN1k/export?format=csv&gid=0" -O /covid19/data/patients.csv
 wget "https://docs.google.com/spreadsheets/d/1DdluQBSQSiACG1CaIg4K3K-HVeGGThyecRHSA84lL6I/export?format=csv&gid=1019512361" -O /covid19/data/main_summary_history.csv
 # wget "https://docs.google.com/spreadsheets/d/1ivROd_s3AmvY480XKEZR_COAlx08gOGxZYRYubxghP0/export?format=csv&gid=0" -O /covid19/data/inspections_summary.csv
 wget "https://docs.google.com/spreadsheets/d/1-w8rowCmCG7lmuo5c0jQ0Dh2Frl4hOmpVrZ2IH9sPpg/export?format=csv&gid=0" -O /covid19/data/inspection_persons_summary.csv
 
 
-# 愛知県HPから感染者一覧を取得してスクレイピング
-python3 /covid19/scrape_patients.py
+# # 愛知県HPから感染者一覧を取得してスクレイピング
+# python3 /covid19/scrape_patients.py
 
 # 愛知県HPから新型コロナウイルス遺伝子検査件数を取得してスクレイピング
 python3 /covid19/scrape_inspections.py


### PR DESCRIPTION
愛知県HPで感染者一覧PDFが公開されなくなったので、

- PDF からのスクレイピングを中止
- Googleスプレッドシートからの取り込みを復活

させました。

Googleスプレッドシートは https://docs.google.com/spreadsheets/d/12qStuXjsI8GE8qI1mLPLV--6TQcxAMPDu3-k9RCHN1k/edit#gid=0 です。