### PR TITLE
復活した要請者一覧PDF(７月までと８月以降)に対応

### DIFF
--- a/docker_exec.sh
+++ b/docker_exec.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-wget "https://docs.google.com/spreadsheets/d/12qStuXjsI8GE8qI1mLPLV--6TQcxAMPDu3-k9RCHN1k/export?format=csv&gid=0" -O /covid19/data/patients.csv
+# wget "https://docs.google.com/spreadsheets/d/12qStuXjsI8GE8qI1mLPLV--6TQcxAMPDu3-k9RCHN1k/export?format=csv&gid=0" -O /covid19/data/patients.csv
 wget "https://docs.google.com/spreadsheets/d/1DdluQBSQSiACG1CaIg4K3K-HVeGGThyecRHSA84lL6I/export?format=csv&gid=1019512361" -O /covid19/data/main_summary_history.csv
 # wget "https://docs.google.com/spreadsheets/d/1ivROd_s3AmvY480XKEZR_COAlx08gOGxZYRYubxghP0/export?format=csv&gid=0" -O /covid19/data/inspections_summary.csv
 wget "https://docs.google.com/spreadsheets/d/1-w8rowCmCG7lmuo5c0jQ0Dh2Frl4hOmpVrZ2IH9sPpg/export?format=csv&gid=0" -O /covid19/data/inspection_persons_summary.csv
 
 
-# # 愛知県HPから感染者一覧を取得してスクレイピング
-# python3 /covid19/scrape_patients.py
+# 愛知県HPから感染者一覧を取得してスクレイピング
+python3 /covid19/scrape_patients.py
 
 # 愛知県HPから新型コロナウイルス遺伝子検査件数を取得してスクレイピング
 python3 /covid19/scrape_inspections.py


### PR DESCRIPTION
close #58 

![image](https://user-images.githubusercontent.com/401369/90308112-a3964e80-df17-11ea-811d-5dc7364f6719.png)

1. 7月まで [PDFファイル／480KB] → source1.pdf → source1.csv
2. 8月まで [PDFファイル／480KB] → source2.pdf → source2.csv
3. 1 と 2 を Pandas でマージ → patients.csv

を生成するようにしました。

Google スプレッドシート(patients) からの変換はコメントアウトしました。