### PR TITLE
pip install で opencv-python==4.3.x を固定

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4
 xlrd
 lxml
 pdfminer.six==20200517
+opencv-python==4.3.0.36


### PR DESCRIPTION
現在 pip install でインストールされる、最新の opencv-python==4.4.x では以下のエラーが発生したため、 requirements.txt で、旧4.3系にバージョンを固定。

```
Traceback (most recent call last):
  File "/covid19/scrape_patients.py", line 29, in <module>
    import camelot
  File "/usr/local/lib/python3.8/site-packages/camelot/__init__.py", line 6, in <module>
    from .io import read_pdf
  File "/usr/local/lib/python3.8/site-packages/camelot/io.py", line 5, in <module>
    from .handlers import PDFHandler
  File "/usr/local/lib/python3.8/site-packages/camelot/handlers.py", line 9, in <module>
  File "/usr/local/lib/python3.8/site-packages/camelot/parsers/__init__.py", line 4, in <module>
    from .lattice import Lattice
  File "/usr/local/lib/python3.8/site-packages/camelot/parsers/lattice.py", line 26, in <module>
    from ..image_processing import (
  File "/usr/local/lib/python3.8/site-packages/camelot/image_processing.py", line 3, in <module>
  File "/usr/local/lib/python3.8/site-packages/cv2/__init__.py", line 5, in <module>
    from .cv2 import *
```