### PR TITLE
「検査陽性者の状況(main_summary_history)」の取得を自動化する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 FROM python:3
 
 # setup
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+    tesseract-ocr \
+    libtesseract-dev \
+    tesseract-ocr-jpn \
+    tesseract-ocr-jpn-vert \
+    tesseract-ocr-script-jpan \
+    tesseract-ocr-script-jpan-vert \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update
 RUN apt-get -y install locales && \
     localedef -f UTF-8 -i ja_JP ja_JP.UTF-8

--- a/docker_exec.sh
+++ b/docker_exec.sh
@@ -4,6 +4,7 @@ echo 1.検査陽性者の状況 start
 wget "https://raw.githubusercontent.com/code4nagoya/covid19/master/data/main_summary_history.csv" -O /covid19/data/main_summary_history_master.csv
 wget "https://docs.google.com/spreadsheets/d/1DdluQBSQSiACG1CaIg4K3K-HVeGGThyecRHSA84lL6I/export?format=csv&gid=1019512361" -O /covid19/data/main_summary_history_sheet.csv
 python3 /covid19/scrape_main_summary.py #愛知県HPからOCR
+cp /covid19/data/main_summary_history_sheet.csv /covid19/data/main_summary_history.csv
 echo 1.検査陽性者の状況 end
 
 echo 2.愛知県内発生事例（感染者一覧） start

--- a/docker_exec.sh
+++ b/docker_exec.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
+echo 1.検査陽性者の状況 start
+wget "https://raw.githubusercontent.com/code4nagoya/covid19/master/data/main_summary_history.csv" -O /covid19/data/main_summary_history_master.csv
+wget "https://docs.google.com/spreadsheets/d/1DdluQBSQSiACG1CaIg4K3K-HVeGGThyecRHSA84lL6I/export?format=csv&gid=1019512361" -O /covid19/data/main_summary_history_sheet.csv
+python3 /covid19/scrape_main_summary.py #愛知県HPからOCR
+echo 1.検査陽性者の状況 end
+
+echo 2.愛知県内発生事例（感染者一覧） start
 # wget "https://docs.google.com/spreadsheets/d/12qStuXjsI8GE8qI1mLPLV--6TQcxAMPDu3-k9RCHN1k/export?format=csv&gid=0" -O /covid19/data/patients.csv
-wget "https://docs.google.com/spreadsheets/d/1DdluQBSQSiACG1CaIg4K3K-HVeGGThyecRHSA84lL6I/export?format=csv&gid=1019512361" -O /covid19/data/main_summary_history.csv
+python3 /covid19/scrape_patients.py #愛知県HPからスクレイピング
+echo 2.愛知県内発生事例（感染者一覧） end
+
+echo 3.検査件数 start
 # wget "https://docs.google.com/spreadsheets/d/1ivROd_s3AmvY480XKEZR_COAlx08gOGxZYRYubxghP0/export?format=csv&gid=0" -O /covid19/data/inspections_summary.csv
+python3 /covid19/scrape_inspections.py #愛知県HPからスクレイピング
+echo 3.検査件数 end
+
+echo 4.検査人数 start
 wget "https://docs.google.com/spreadsheets/d/1-w8rowCmCG7lmuo5c0jQ0Dh2Frl4hOmpVrZ2IH9sPpg/export?format=csv&gid=0" -O /covid19/data/inspection_persons_summary.csv
+echo 4.検査人数 end
 
-
-# 愛知県HPから感染者一覧を取得してスクレイピング
-python3 /covid19/scrape_patients.py
-
-# 愛知県HPから新型コロナウイルス遺伝子検査件数を取得してスクレイピング
-python3 /covid19/scrape_inspections.py
-
+echo 5.data.json 生成 start
 python3 /covid19/build_json.py `date -d "1 day ago" +'%Y-%m-%d'` > /covid19/data/data.json
+echo 5.data.json 生成 end
 
 # cat /covid19/data/*.json /covid19/data/*.csv
 ls /covid19/data/*.json /covid19/data/*.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ xlrd
 lxml
 pdfminer.six==20200517
 opencv-python==4.3.0.36
+requests
+html5lib
+pytesseract

--- a/scrape_main_summary.py
+++ b/scrape_main_summary.py
@@ -1,0 +1,88 @@
+'''
+このコードはimabariさんのコードを元に作成しています。
+
+https://github.com/imabari/covid19-data/blob/master/aichi/aichi_ocr.ipynb
+'''
+
+import pathlib
+import re
+
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+try:
+    from PIL import Image
+except ImportError:
+    import Image
+    
+import pytesseract
+import cv2
+import datetime
+import csv
+
+def get_file(url, dir="."):
+
+    r = requests.get(url)
+
+    p = pathlib.Path(dir, "main_summary" + pathlib.PurePath(url).suffix)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    with p.open(mode='wb') as fw:
+        fw.write(r.content)
+
+    return p
+
+def recognition(jpg_path):
+    src = cv2.imread(str(jpg_path))
+    img = cv2.inRange(src, (150, 150, 100), (255, 255, 255))
+
+    # 範囲指定
+    img_crop = img[0:550]
+    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 6").replace(".", "")
+    print(txt)
+
+    dt_match = re.search("(\d{4})年(\d{1,2})月(\d{1,2})日(\d{1,2})時", txt)    
+    y, m, d, h = map(int, dt_match.groups())
+    dt_update = datetime.datetime(y, m, d, h).strftime("%Y/%m/%d %H:00")
+
+    # ※1 ※2 または (注) で始まる文を抽出
+    remarks = re.findall("^(※. .*|\(注\) .*)$", txt, re.M)
+    # 行頭の ※1 ※2 や (注) を削除（空白以降を抽出）
+    remarks = list(map(lambda word:word[word.find(' ')+1:], remarks))
+
+    # xx人 な箇所を全て抜き出す
+    data = list(map(lambda str:str.replace('人', ''), re.findall("[0-9]+人", txt))) 
+    # dataの先頭から [検査実施人数,陽性患者数,入院,軽症無症状,中等症,重症,入院調整,施設入所,自宅療養,調整,退院,死亡] であると決め打ち
+    data = data[0:12]
+
+    return [dt_update, data, remarks]
+
+def to_csv(dt, row, remarks, dir):
+    p = pathlib.Path(dir, 'main_summary_recognized.csv')
+
+    with p.open(mode='w') as fw:
+        writer = csv.writer(fw)
+        writer.writerow(["更新日時","検査実施人数","陽性患者数","入院","軽症無症状","中等症","重症","入院調整","施設入所","自宅療養","調整","退院","死亡","入院中","軽症中等症","転院","備考"])
+        writer.writerow([dt] + row + ["", "", ""] + ["".join(remarks)])
+
+if __name__ == "__main__":
+    url = "https://www.pref.aichi.jp/site/covid19-aichi/"
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko",
+    }
+    r = requests.get(url, headers=headers)
+
+    r.raise_for_status()
+
+    soup = BeautifulSoup(r.content, "html5lib")
+    src = soup.find("img", alt=re.compile("検査陽性者$")).get("src")
+    link = urljoin(url, src)
+    jpg_path = get_file(link, "./data")
+    res = recognition(jpg_path)
+    print(res[0])
+    print(res[1])
+    print(res[2])
+
+    to_csv(res[0], res[1], res[2], "./data")


### PR DESCRIPTION
ref #44

@imabari さんが作成された https://github.com/code4nagoya/covid19-aichi-tools/issues/44#issuecomment-628611354 の ``aichi_ocr.ipynb`` を組み込み、修正して愛知県HPの検査陽性者の状況の画像から自動で main_summary_history の1行分の内容を抽出します。

ただ現状は Google Spreadsheet との兼ね合いで自動抽出したデータは data.json にマージしていません。マージ戦略については要検討です。

この PR は、元の画像から１行のCSVを抽出するテストのために作成したものです。
以下に、その例を載せておきます。

## 元画像

![main_summary](https://user-images.githubusercontent.com/401369/90421236-0cd2b900-e0f4-11ea-9bc1-a65947527016.jpg)

## 変換後１行CSV

```
更新日時,検査実施人数,陽性患者数,入院,軽症無症状,中等症,重症,入院調整,施設入所,自宅療養,調整,退院,死亡,入院中,軽症中等症,転院,備考
2020/08/16 20:00,37041,3739,336,248,75,13,37,55,936,83,2248,44,,,,検査実施人数については、発表時点での把握数。なお、検査件数は、48180件。陽性者数については、中国人渡航者2人を除く。また、再感染7人については、含めていない。検査実施人数には県内において疑い例または患者の濃厚接触者として検査を行ったものについて掲

```
