### PR TITLE
検査陽性者の状況のCSV群のマージを実装

### DIFF
--- a/docker_exec.sh
+++ b/docker_exec.sh
@@ -4,7 +4,8 @@ echo 1.検査陽性者の状況 start
 wget "https://raw.githubusercontent.com/code4nagoya/covid19/master/data/main_summary_history.csv" -O /covid19/data/main_summary_history_master.csv
 wget "https://docs.google.com/spreadsheets/d/1DdluQBSQSiACG1CaIg4K3K-HVeGGThyecRHSA84lL6I/export?format=csv&gid=1019512361" -O /covid19/data/main_summary_history_sheet.csv
 python3 /covid19/scrape_main_summary.py #愛知県HPからOCR
-cp /covid19/data/main_summary_history_sheet.csv /covid19/data/main_summary_history.csv
+python3 /covid19/merge_main_summary.py #CSV群を main_summary_history.csv にマージ
+# cp /covid19/data/main_summary_history_sheet.csv /covid19/data/main_summary_history.csv
 echo 1.検査陽性者の状況 end
 
 echo 2.愛知県内発生事例（感染者一覧） start

--- a/merge_main_summary.py
+++ b/merge_main_summary.py
@@ -62,6 +62,6 @@ if __name__ == "__main__":
     # 更新日時の昇順で並び替えてCSV出力
     df_csv = df_csv.sort_values(by=[dt_col], ascending=True)
     # df_csv = df_csv.astype(str)
-    order = ["更新日時","検査実施人数","陽性患者数","入院","入院_軽症無症状","中等症","重症","入院調整","施設入所","自宅療養","調整","退院","死亡","入院中","軽症無症状","軽症中等症","転院","備考"]
+    order = ["更新日時","検査実施人数","陽性患者数","入院","軽症無症状","中等症","重症","入院調整","施設入所","自宅療養","調整","退院","死亡","入院中","軽症中等症","転院","備考"]
     df_csv[order].to_csv("./data/main_summary_history.csv", index=False, header=True)
     print("Wrote to main_summary_history.csv")

--- a/merge_main_summary.py
+++ b/merge_main_summary.py
@@ -1,0 +1,67 @@
+'''
+このコードはimabariさんのコードを元に作成しています。
+
+https://github.com/imabari/covid19-data/blob/master/aichi/aichi_ocr.ipynb
+'''
+
+import pathlib
+import re
+
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+try:
+    from PIL import Image
+except ImportError:
+    import Image
+    
+import pytesseract
+import cv2
+import datetime
+import os
+import csv
+import pandas as pd
+
+if __name__ == "__main__":
+
+    dt_col = "更新日時"
+    date_col = "更新日"
+
+    # 更新日時列 → 更新日列 の生成
+    def update_at_ymd(x):
+        return x[dt_col][:x[dt_col].find(' ')]
+
+    # 前回CSV読み込み
+    df_master = pd.read_csv("./data/main_summary_history_master.csv", dtype=str)
+    df_master[date_col] = df_master.apply(update_at_ymd, axis=1) # 更新日列追加
+    
+    # OCR結果CSV読み込み
+    ocr_path = "./data/main_summary_recognized.csv"
+    if os.path.isfile(ocr_path):
+        df_recog = pd.read_csv(ocr_path, dtype=str)
+        df_recog[date_col] = df_recog.apply(update_at_ymd, axis=1) # 更新日列追加
+
+        # 前回CSVとOCR結果CSVをマージ(同一更新日はOCR結果CSVを採用)
+        df_merged = df_recog.set_index(date_col).combine_first(df_master.set_index(date_col))
+        df_merged[date_col] = df_merged.apply(update_at_ymd, axis=1) # 更新日列追加
+        print("Merged main_summary_history_master.csv to main_summary_recognized.csv")
+
+    else:
+        print("main_summary_recognized.csv not found, skipped.")
+        df_merged = df_master
+
+    # GoogleスプレッドシートCSV読み込み
+    df_sheet = pd.read_csv("./data/main_summary_history_sheet.csv", dtype=str)
+    df_sheet[date_col] = df_sheet.apply(update_at_ymd, axis=1) # 更新日列追加
+
+    # さらにGoogleスプレッドシートCSVをマージ(同一更新日はGoogleスプレッドシートCSVを採用)
+    df_csv = df_sheet.set_index(date_col).combine_first(df_merged.set_index(date_col))
+    print("Merged to main_summary_history_sheet.csv")
+
+    # 更新日時の昇順で並び替えてCSV出力
+    df_csv = df_csv.sort_values(by=[dt_col], ascending=True)
+    # df_csv = df_csv.astype(str)
+    order = ["更新日時","検査実施人数","陽性患者数","入院","入院_軽症無症状","中等症","重症","入院調整","施設入所","自宅療養","調整","退院","死亡","入院中","軽症無症状","軽症中等症","転院","備考"]
+    df_csv[order].to_csv("./data/main_summary_history.csv", index=False, header=True)
+    print("Wrote to main_summary_history.csv")

--- a/scrape_main_summary.py
+++ b/scrape_main_summary.py
@@ -80,15 +80,16 @@ def to_csv(dt, row, remarks, dir):
 
     with p.open(mode='w') as fw:
         writer = csv.writer(fw)
-        writer.writerow(["更新日時","検査実施人数","陽性患者数","入院","入院_軽症無症状","中等症","重症","入院調整","施設入所","自宅療養","調整","退院","死亡","入院中","軽症無症状","軽症中等症","転院","備考"])
+        writer.writerow(["更新日時","検査実施人数","陽性患者数","入院","軽症無症状","中等症","重症","入院調整","施設入所","自宅療養","調整","退院","死亡","入院中","軽症中等症","転院","備考"])
 
         # 入院中（実際には現在陽性者数）： 入院＋入院調整＋自宅療養＋調整
         # 軽症無症状: 入院中－中等症－重症
         # 軽症中等症: null固定
         # 転院: 0固定
-        patient_num = row[2] + row[6] + row[8] + row[9]
+        # patient_num = row[2] + row[6] + row[8] + row[9]
         inactive_num = patient_num - row[4] - row[5]
-        writer.writerow([dt] + row + [patient_num, inactive_num, "", 0] + ["".join(remarks)])
+        # writer.writerow([dt] + row + [patient_num, inactive_num, "", 0] + ["".join(remarks)])
+        writer.writerow([dt] + row + [inactive_num, "", 0] + ["".join(remarks)])
 
 if __name__ == "__main__":
     url = "https://www.pref.aichi.jp/site/covid19-aichi/"

--- a/scrape_main_summary.py
+++ b/scrape_main_summary.py
@@ -40,7 +40,7 @@ def recognition(jpg_path):
     # 範囲指定
     img_crop = img[0:550]
     # ref http://blog.machine-powers.net/2018/08/02/learning-tesseract-command-utility/
-    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 1").replace(".", "")
+    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 11").replace(".", "")
     print(txt)
 
     dt_match = re.search("(\d{4})年(\d{1,2})月(\d{1,2})日(\d{1,2})時", txt)    
@@ -62,7 +62,7 @@ def recognition(jpg_path):
     remarks = list(map(normalize, remarks))
 
     # xx人 な箇所を全て抜き出す
-    data = list(map(lambda str:int(str.replace('人', '')), re.findall("[0-9]+人", txt))) 
+    data = list(map(lambda str:int(str.replace('人', '')), re.findall("[0-9]+人", txt.replace(',', ''))))
     # dataの先頭から [検査実施人数,陽性患者数,入院,入院_軽症無症状,中等症,重症,入院調整,施設入所,自宅療養,調整,退院,死亡] であると決め打ち
     data = data[0:12]
 

--- a/scrape_main_summary.py
+++ b/scrape_main_summary.py
@@ -35,12 +35,12 @@ def get_file(url, dir="."):
 
 def recognition(jpg_path):
     src = cv2.imread(str(jpg_path))
-    img = cv2.inRange(src, (150, 150, 100), (255, 255, 255))
+    img = cv2.inRange(src, (150, 120, 130), (255, 255, 255))
 
     # 範囲指定
     img_crop = img[0:550]
     # ref http://blog.machine-powers.net/2018/08/02/learning-tesseract-command-utility/
-    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 11").replace(".", "")
+    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 3").replace(".", "").replace(",", "")
     print(txt)
 
     dt_match = re.search("(\d{4})年(\d{1,2})月(\d{1,2})日(\d{1,2})時", txt)    

--- a/scrape_main_summary.py
+++ b/scrape_main_summary.py
@@ -39,7 +39,8 @@ def recognition(jpg_path):
 
     # 範囲指定
     img_crop = img[0:550]
-    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 6").replace(".", "")
+    # ref http://blog.machine-powers.net/2018/08/02/learning-tesseract-command-utility/
+    txt = pytesseract.image_to_string(img_crop, lang="jpn", config="--psm 1").replace(".", "")
     print(txt)
 
     dt_match = re.search("(\d{4})年(\d{1,2})月(\d{1,2})日(\d{1,2})時", txt)    
@@ -86,7 +87,7 @@ def to_csv(dt, row, remarks, dir):
         # 軽症無症状: 入院中－中等症－重症
         # 軽症中等症: null固定
         # 転院: 0固定
-        # patient_num = row[2] + row[6] + row[8] + row[9]
+        patient_num = row[2] + row[6] + row[8] + row[9]
         inactive_num = patient_num - row[4] - row[5]
         # writer.writerow([dt] + row + [patient_num, inactive_num, "", 0] + ["".join(remarks)])
         writer.writerow([dt] + row + [inactive_num, "", 0] + ["".join(remarks)])


### PR DESCRIPTION
ref #44 

https://github.com/code4nagoya/covid19-aichi-tools/issues/44#issuecomment-675539849 の以下の流れを実装しました。

1. 前提として、1日1行のデータとする（1日に複数行は無いとする）
2. 前回変換した main_summary_history.csv を [現在公開されているサイト](https://github.com/code4nagoya/covid19/blob/master/data/main_summary_history.csv) から取得する → A とする
3. 画像から OCR する → B とする
    * OCR結果のチェックで不整合 → B は出力しない。また、ログにはエラーを出力する。処理は続行する。
4. A と B をマージする → C とする（B が A に既存ならマージしない）
    * B が存在しない場合、A を C として処理を続行する
5. Google スプレッドシートからデータを取得する → D とする
6. C と D をマージする → E とする（D が C に既存の場合、その日の行を上書きする）
7. E を最終結果とする


これをマージしたら、OCR が成功すれば Google スプレッドシートへの記入は不要になります。