### PR TITLE
愛知県HPのtypoに対応

### DIFF
--- a/scrape_patients.py
+++ b/scrape_patients.py
@@ -123,8 +123,8 @@ def exceltime2datetime(et):
     return pd.to_datetime('1900/1/1') + days
 
 if __name__ == "__main__":
-    FILE_PATH1, extension1 = findpath("/site/covid19-aichi/kansensya-kensa.html", "7月まで")
-    FILE_PATH2, extension2 = findpath("/site/covid19-aichi/kansensya-kensa.html", "8月以降")
+    FILE_PATH1, extension1 = findpath("/site/covid19-aichi/kansensya-kensa.html", "7月")
+    FILE_PATH2, extension2 = findpath("/site/covid19-aichi/kansensya-kensa.html", "8月")
     try:
         if extension1 == "xlsx":
             df1 = convert_xlsx(FILE_PATH1, "./data/source1.xlsx")


### PR DESCRIPTION
2020/08/30時点HPは「８月以降」が「８月まで」になってたので検索文字を「８月」に変更。
また typo されるかも知れないので７月ともどもこのままにしておく。

![image](https://user-images.githubusercontent.com/401369/91649798-c2b5e400-eab2-11ea-9d5f-ad5bd7bac821.png)
