### PR TITLE
fix 検査陽性者の状況OCRがエラーになってた

### DIFF
--- a/recognize_main_summary_date_1.py
+++ b/recognize_main_summary_date_1.py
@@ -4,7 +4,7 @@
 import re
 import pytesseract
 import cv2
-import datetime
+from datetime import datetime, timezone, timedelta
 
 def recognize(jpg_path):
     src = cv2.imread(str(jpg_path))
@@ -28,17 +28,18 @@ def recognize(jpg_path):
     print(txt)
 
     # 取得した日付が 5日前～現在 の間だったら有効とする
-    rangeEnd = datetime.now()
-    rangeStart = rangeEnd - datetime.timedelta(days=5)
+    JST = timezone(timedelta(hours=+9), 'JST')
+    rangeEnd = datetime.now(JST)
+    rangeStart = rangeEnd - timedelta(days=5)
 
     # 年月日時を抽出1
     dt_match = re.search("(\d{4}).*年(\d{1,2}).*月(\d{1,2}).*日(\d{1,2}).*", txt)    
     print(dt_match)
     if dt_match is not None and len(dt_match.groups()) == 4:
         y, m, d, h = map(int, dt_match.groups())
-        dt_update = datetime.datetime(y, m, d, h)
+        dt_update = datetime(y, m, d, h, tzinfo=JST)
         print(dt_update)
-        if rangeEnd < dt_update & dt_update < rangeEnd:
+        if (rangeStart < dt_update) & (dt_update < rangeEnd):
             return dt_update.strftime("%Y/%m/%d %H:00")
 
     # 年月日時を抽出2
@@ -46,9 +47,9 @@ def recognize(jpg_path):
     print(dt_match.groups())
     if dt_match is not None and len(dt_match.groups()) == 4:
         y, m, d, h = map(int, dt_match.groups())
-        dt_update = datetime.datetime(y, m, d, h)
+        dt_update = dt.datetime(y, m, d, h, tzinfo=JST)
         print(dt_update)
-        if rangeEnd < dt_update & dt_update < rangeEnd:
+        if (rangeStart < dt_update) & (dt_update < rangeEnd):
             return dt_update.strftime("%Y/%m/%d %H:00")
 
     # 年月日だけでも抽出
@@ -56,9 +57,9 @@ def recognize(jpg_path):
     print(txt)
     if dt_match is not None and len(dt_match.groups()) == 3:
         y, m, d = map(int, dt_match.groups())
-        dt_update = datetime.datetime(y, m, d, 0)
+        dt_update = dt.datetime(y, m, d, 0, tzinfo=JST)
         print(dt_update)
-        if rangeEnd < dt_update & dt_update < rangeEnd:
+        if (rangeStart < dt_update) & (dt_update < rangeEnd):
             return dt_update.strftime("%Y/%m/%d %0:00")
 
     raise ValueError("OCR Failed. 更新日が取得できませんでした。")

--- a/recognize_main_summary_date_2.py
+++ b/recognize_main_summary_date_2.py
@@ -4,7 +4,7 @@
 import re
 import pytesseract
 import cv2
-import datetime
+from datetime import datetime, timezone, timedelta
 import numpy as np
 
 # 拡大と白黒化
@@ -50,7 +50,8 @@ def recognize(jpg_path):
     print(txt)
 
     # 取得した日付が 5日前～現在 の間だったら有効とする
-    rangeEnd = datetime.now()
+    JST = timezone(timedelta(hours=+9), 'JST')
+    rangeEnd = datetime.now(JST)
     rangeStart = rangeEnd - datetime.timedelta(days=5)
 
     # 年月日時を抽出1
@@ -58,9 +59,9 @@ def recognize(jpg_path):
     print(dt_match)
     if dt_match is not None and len(dt_match.groups()) == 4:
         y, m, d, h = map(int, dt_match.groups())
-        dt_update = datetime.datetime(y, m, d, h)
+        dt_update = datetime.datetime(y, m, d, h, tzinfo=JST)
         print(dt_update)
-        if rangeEnd < dt_update & dt_update < rangeEnd:
+        if (rangeStart < dt_update) & (dt_update < rangeEnd):
             return dt_update.strftime("%Y/%m/%d %H:00")
 
     # 年月日時を抽出2
@@ -68,9 +69,9 @@ def recognize(jpg_path):
     print(dt_match.groups())
     if dt_match is not None and len(dt_match.groups()) == 4:
         y, m, d, h = map(int, dt_match.groups())
-        dt_update = datetime.datetime(y, m, d, h)
+        dt_update = datetime.datetime(y, m, d, h, tzinfo=JST)
         print(dt_update)
-        if rangeEnd < dt_update & dt_update < rangeEnd:
+        if (rangeStart < dt_update) & (dt_update < rangeEnd):
             return dt_update.strftime("%Y/%m/%d %H:00")
 
     # 年月日だけでも抽出
@@ -78,9 +79,9 @@ def recognize(jpg_path):
     print(txt)
     if dt_match is not None and len(dt_match.groups()) == 3:
         y, m, d = map(int, dt_match.groups())
-        dt_update = datetime.datetime(y, m, d, 0)
+        dt_update = datetime.datetime(y, m, d, 0, tzinfo=JST)
         print(dt_update)
-        if rangeEnd < dt_update & dt_update < rangeEnd:
+        if (rangeStart < dt_update) & (dt_update < rangeEnd):
             return dt_update.strftime("%Y/%m/%d %0:00")
 
     raise ValueError("OCR Failed. 更新日が取得できませんでした。")

--- a/scrape_main_summary.py
+++ b/scrape_main_summary.py
@@ -12,7 +12,6 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 
 import pytesseract
-import datetime
 import csv
 
 import recognize_main_summary_date_1 as date_pattern1


### PR DESCRIPTION
## 1

``if rangeEnd < dt_update & dt_update < rangeEnd:`` でオペランドエラーになってた（python 3.8 にしたから？）。
``if (rangeEnd < dt_update) & (dt_update < rangeEnd):`` に修正。

## 2

timezone を指定してなかったので、GMT vs JST で比較していた

## 3

「5日前」の比較ができてなかった。
