### PR TITLE
愛知県内の発生事例PDFの欠番行を除外

### DIFF
--- a/scrape_patients.py
+++ b/scrape_patients.py
@@ -115,6 +115,8 @@ def convert_pdf(FILE_PATHs):
 
     # 発表日が欠損を削除
     df.dropna(subset=["発表日"], inplace=True)
+    # 欠番の行を削除
+    df = df[~df["発表日"].str.contains("欠番")]
 
     # Noを数値に変換
     df.index = df.index.astype(int)


### PR DESCRIPTION
https://github.com/code4nagoya/covid19/issues/336#issuecomment-782784556

にて報告された No. 25188 の行が 「（欠番）」となったために、定時のデータ取り込みが失敗していたので、それを解消。

具体的には、"欠番" が含まれる行を除外した。