### PR TITLE
fix 事後追加された過去の県内発生事例が未来の日付と判断される

### DIFF
--- a/scrape_patients.py
+++ b/scrape_patients.py
@@ -86,8 +86,11 @@ def fetch_file(url, dir="."):
 def days2date(s):
 
     # No.16577以降は2021年
-    # TODO Noが変わる可能性があるので決め打ちはやめたい。"1月" に変化する度に year を加算する？
     y = 2021 if s.name > 16576 else 2020
+
+    # 以下の No は事後発表なので 2020年
+    if s.name in [25753, 25754, 25755]:
+        y = 2020    
 
     days = re.findall("[0-9]{1,2}", s["発表日"])
 


### PR DESCRIPTION
close #93 

https://github.com/code4nagoya/covid19/issues/1103#issuecomment-786673523

を適用して 25753, 25754, 25755 の3件を 2020年 とみなした。